### PR TITLE
fix: file name of gzipped cache

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,7 +104,7 @@ async function fetchFile (DIR, filehash, fileurl) {
       }
 
       await writeFile(path.resolve(DIR, 'file.data'), body, 'binary')
-      await writeFile(path.resolve(DIR, 'file.gz.data'), zlib.gzipSync(body, {
+      await writeFile(path.resolve(DIR, 'file.gzip.data'), zlib.gzipSync(body, {
         level: 9
       }), 'binary')
       await writeFile(path.resolve(DIR, 'file.br.data'), zlib.brotliCompressSync(body), 'binary')


### PR DESCRIPTION
#### [app.js#L176](https://github.com/isXiaoLin/One/blob/bedc5ef9217b03bdaa60d0f64e1cf46a4b5bc8b5/app.js#L176)

```javascript
acceptEncoding = 'gzip'
```

#### [app.js#L199](https://github.com/isXiaoLin/One/blob/bedc5ef9217b03bdaa60d0f64e1cf46a4b5bc8b5/app.js#L199)

```javascript
res.end(await readFile(path.resolve(DIR, `file.${acceptEncoding}data`), {
```